### PR TITLE
Remco missing and new items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,21 @@ Changelog of ribxlib
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Refactored parsers.py a lot; there is now a single parser for
+  all types of element.
+
+- Return "InspectionManholes" and "CleaningManholes" separately (and
+  the same for pipes). This means lizard-progress can check that the
+  right type was used, which will protect against some annoying errors
+  users made (uploading a file to the wrong Activity and having it
+  accepted, overwriting the right data).
+
+- Check for "XD" tags in element headers, which signify that it was not
+  possible to do that part of the assigned work. The commentary is
+  gatherered and returned too, for use in lizard-progress.
+
+- Check for "XC" tags in element headers, which signify that the element
+  was not part of the assigned work ("found in the field").
 
 
 0.3 (2015-06-09)

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -40,17 +40,28 @@ class Ribx(object):
         return media
 
 
-class Pipe(object):
-    """Sewerage pipe (`rioolbuis` in Dutch).
+class Thing(object):
+    """Common superclass for the various kinds of things. The more we
+    can put in here, the better."""
+    has_video = False
 
-    """
     def __init__(self, ref):
         self.ref = ref
-        self.manhole1 = None
-        self.manhole2 = None
         self.inspection_date = None
         self.media = set()
         self.sourceline = None
+
+
+class Pipe(Thing):
+    """Sewerage pipe (`rioolbuis` in Dutch).
+
+    """
+    has_video = True
+
+    def __init__(self, ref):
+        super(Pipe, self).__init__(ref)
+        self.manhole1 = None
+        self.manhole2 = None
 
     def __str__(self):
         return self.ref
@@ -66,31 +77,45 @@ class Pipe(object):
             logger.error(e)
 
 
-class Manhole(object):
+class InspectionPipe(Pipe):
+    tag = 'ZB_A'
+
+
+class CleaningPipe(Pipe):
+    tag = 'ZB_G'
+
+
+class Manhole(Thing):
     """A covered hole to a sewerage pipe (`put` in Dutch).
 
     """
+    has_video = True
+
     def __init__(self, ref):
-        self.ref = ref
+        super(Manhole, self).__init__(ref)
         self.geom = None
-        self.inspection_date = None
-        self.media = set()
-        self.sourceline = None
 
     def __str__(self):
         return self.ref
 
 
-class Drain(object):
+class InspectionManhole(Manhole):
+    tag = 'ZB_C'
+
+
+class CleaningManhole(Manhole):
+    tag = 'ZB_J'
+
+
+class Drain(Thing):
     """A storm drain (`kolk` in Dutch).
 
     """
+    tag = 'ZB_E'
+
     def __init__(self, ref):
-        self.ref = ref
+        super(Drain, self).__init__(ref)
         self.geom = None
-        self.inspection_date = None
-        self.media = set()
-        self.sourceline = None
         self.owner = ''
 
     def __str__(self):

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -51,6 +51,8 @@ class Thing(object):
         self.media = set()
         self.sourceline = None
         self.work_impossible = None  # If it was, this holds the reason
+        self.new = False  # True if a '*XC' tag was used ("ontbreekt
+                          # in opdracht")
 
     @classmethod
     def xd_explanation(self, xd):

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -40,26 +40,40 @@ class Ribx(object):
         return media
 
 
-class Thing(object):
-    """Common superclass for the various kinds of things. The more we
+class SewerElement(object):
+    """Common superclass for pipes, drains and manholes. The more we
     can put in here, the better."""
+    # According to the spec, not everything can have the video
+    # tag. Subclasses that can set this to True.
     has_video = False
 
     def __init__(self, ref):
+        # Code of this element
         self.ref = ref
+
+        # Stays empty if file is used to describe the work to be done, must be
+        # filled in if the work was done (or turned out not to be possible).
         self.inspection_date = None
+
+        # A set of related filenames that will be uploaded later.
         self.media = set()
+
+        # Line in the RIBX file where this element's node started.
         self.sourceline = None
-        self.work_impossible = None  # If it was, this holds the reason
-        self.new = False  # True if a '*XC' tag was used ("ontbreekt
-                          # in opdracht")
+
+        # Sometimes it was impossible to do the work, if so then this element
+        # will contain the reason as a string.
+        self.work_impossible = None
+
+        # True if a '*XC' tag was used ("ontbreekt in opdracht")
+        self.new = False
 
     @classmethod
     def xd_explanation(self, xd):
         return xd
 
 
-class Pipe(Thing):
+class Pipe(SewerElement):
     """Sewerage pipe (`rioolbuis` in Dutch).
 
     """
@@ -102,7 +116,7 @@ class CleaningPipe(Pipe):
     tag = 'ZB_G'
 
 
-class Manhole(Thing):
+class Manhole(SewerElement):
     """A covered hole to a sewerage pipe (`put` in Dutch).
 
     """
@@ -137,7 +151,7 @@ class CleaningManhole(Manhole):
     tag = 'ZB_J'
 
 
-class Drain(Thing):
+class Drain(SewerElement):
     """A storm drain (`kolk` in Dutch).
 
     """

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -22,18 +22,21 @@ class ParseException(Exception):
 class Ribx(object):
 
     def __init__(self):
-        self.pipes = []
-        self.manholes = []
+        self.inspection_pipes = []
+        self.cleaning_pipes = []
+        self.inspection_manholes = []
+        self.cleaning_manholes = []
         self.drains = []
 
     @property
     def media(self):
+        """Combine the media sets of all elements in this RIBX."""
         media = set()
-        for pipe in self.pipes:
+        for pipe in self.inspection_pipes + self.cleaning_pipes:
             media.update(pipe.media)
             media.update(pipe.manhole1.media)
             media.update(pipe.manhole2.media)
-        for manhole in self.manholes:
+        for manhole in self.inspection_manholes + self.cleaning_manholes:
             media.update(manhole.media)
         for drain in self.drains:
             media.update(drain.media)

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -50,6 +50,11 @@ class Thing(object):
         self.inspection_date = None
         self.media = set()
         self.sourceline = None
+        self.work_impossible = None  # If it was, this holds the reason
+
+    @classmethod
+    def xd_explanation(self, xd):
+        return xd
 
 
 class Pipe(Thing):
@@ -76,6 +81,16 @@ class Pipe(Thing):
         except Exception as e:
             logger.error(e)
 
+    @classmethod
+    def xd_explanation(self, xd):
+        # Taken from the modelbeschrijving PDF page 41, see
+        # ribxlib/doc.
+        return {
+            'A': 'Voertuig/obstakel op toegang',
+            'B': 'Straat niet toegankelijk voor het voertuig',
+            'Z': 'Andere reden.'
+        }.get(xd, 'Onbekende xXD code {}'.format(xd))
+
 
 class InspectionPipe(Pipe):
     tag = 'ZB_A'
@@ -97,6 +112,19 @@ class Manhole(Thing):
 
     def __str__(self):
         return self.ref
+
+    @classmethod
+    def xd_explanation(self, xd):
+        # Taken from the modelbeschrijving PDF page 46, see
+        # ribxlib/doc.
+        return {
+            'A': 'Voertuig/obstakel op toegang',
+            'B': 'Straat niet toegankelijk voor het voertuig',
+            'C': 'Groen blokkeert de toegang',
+            'D': 'Niet aangetroffen',
+            'E': 'Deksel vast',
+            'Z': 'Andere reden.'
+        }.get(xd, 'Onbekende xXD code {}'.format(xd))
 
 
 class InspectionManhole(Manhole):

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -76,16 +76,11 @@ def parse(f, mode):
     cleaning_manhole_parser = TreeParser(
         tree, models.CleaningManhole, mode, error_log)
 
+    ribx.inspection_pipes = inspection_pipe_parser.elements()
+    ribx.cleaning_pipes = cleaning_pipe_parser.elements()
+    ribx.inspection_manholes = inspection_manhole_parser.elements()
+    ribx.cleaning_manholes = cleaning_manhole_parser.elements()
     ribx.drains = drain_parser.elements()
-
-    # The next two should really be split, but for backwards
-    # compatibility, don't do that yet.
-    ribx.manholes = (
-        inspection_manhole_parser.elements() +
-        cleaning_manhole_parser.elements())
-    ribx.pipes = (
-        inspection_pipe_parser.elements() +
-        cleaning_pipe_parser.elements())
 
     return ribx, error_log
 

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -165,7 +165,7 @@ class ElementParser(object):
 
         instance.inspection_date = self.get_inspection_date()
 
-        if isinstance(self.model, models.Pipe):
+        if issubclass(self.model, models.Pipe):
             # We need two manholes and two sets of coordinates.
             manhole1_ref, manhole1_sourceline = self.tag_value(
                 'AD', complain=True)
@@ -174,7 +174,7 @@ class ElementParser(object):
             instance.manhole1.geom = self.tag_point('AE')
 
             manhole2_ref, manhole2_sourceline = self.tag_value(
-                self.node, 'AF', complain=True)
+                'AF', complain=True)
             instance.manhole2 = models.Manhole(manhole2_ref)
             instance.manhole2.sourceline = manhole2_sourceline
             instance.manhole2.geom = self.tag_point('AG')
@@ -240,7 +240,7 @@ class ElementParser(object):
                 raise Exception(
                     'Expected explanation for Z code in {} tag'
                     .format(self.tag('DE')))
-            elif xd != 'Z' and not attr_explanation:
+            elif xd != 'Z' and attr_explanation:
                 raise Exception(
                     'Explanation in {} tag not allowed without Z code.'
                     .format(self.tag('DE')))

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -1,4 +1,4 @@
-# (c) Nelen & SchuurmOans.  GPL licensed, see LICENSE.rst.
+# (c) Nelen & Schuurmans.  GPL licensed, see LICENSE.rst.
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -187,6 +187,11 @@ class ThingParser(object):
         # Maybe inspection / cleaning wasn't possible
         instance.work_impossible = self.get_work_impossible()
 
+        # If a *XC tag exists, this thing was new, not planned
+        # *XC = "Ontbreekt in opracht"
+        if self.xpath(self.tag('XC')):
+            instance.new = True
+
         # ZC nodes
         for observation in self.get_observations():
             instance.media.update(observation.media())
@@ -226,6 +231,14 @@ class ThingParser(object):
             xd_explanation = self.model.xd_explanation(xd)
 
             attr_explanation = self.tag_attribute('XD', 'DE') or ''
+            if xd == 'Z' and not attr_explanation:
+                raise Exception(
+                    'Expected explanation for Z code in {} tag'
+                    .format(self.tag('DE')))
+            elif xd != 'Z' and not attr_explanation:
+                raise Exception(
+                    'Explanation in {} tag not allowed without Z code.'
+                    .format(self.tag('DE')))
 
             tag_explanation, sourceline = self.tag_value('DE')
 

--- a/ribxlib/tests/test_models.py
+++ b/ribxlib/tests/test_models.py
@@ -1,9 +1,6 @@
 import unittest
 
-from ribxlib.models import Drain
-from ribxlib.models import Manhole
-from ribxlib.models import Pipe
-from ribxlib.models import Ribx
+from ribxlib import models
 
 
 class ModelTest(unittest.TestCase):
@@ -12,21 +9,21 @@ class ModelTest(unittest.TestCase):
         """Docstring.
 
         """
-        ribx = Ribx()
+        ribx = models.Ribx()
 
-        pipe = Pipe("Pipe")
-        ribx.pipes.append(pipe)
+        pipe = models.CleaningPipe("Pipe")
+        ribx.cleaning_pipes.append(pipe)
 
-        manhole1 = Manhole("Manhole1")
+        manhole1 = models.CleaningManhole("Manhole1")
         pipe.manhole1 = manhole1
 
-        manhole2 = Manhole("Manhole2")
+        manhole2 = models.CleaningManhole("Manhole2")
         pipe.manhole2 = manhole2
 
-        manhole3 = Manhole("Manhole3")
-        ribx.manholes.append(manhole3)
+        manhole3 = models.CleaningManhole("Manhole3")
+        ribx.cleaning_manholes.append(manhole3)
 
-        drain = Drain("Drain")
+        drain = models.Drain("Drain")
         ribx.drains.append(drain)
 
         pipe.media.add("video.mpg")

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -30,3 +30,30 @@ class TestThingParser(unittest.TestCase):
             'Explanation in EDE' in instance.work_impossible)
         self.assertTrue(
             'Explanation in attribute' in instance.work_impossible)
+
+    def test_item_is_not_new(self):
+        self.parser.node = XML("""
+        <ZB_E>
+          <EAA>whee</EAA>
+          <EBF>2015-7-3</EBF>
+          <ZC>
+          </ZC>
+        </ZB_E>
+        """)
+
+        instance = self.parser.parse()
+        self.assertFalse(instance.new)
+
+    def test_item_with_xc_is_new(self):
+        self.parser.node = XML("""
+        <ZB_E>
+          <EAA>whee</EAA>
+          <EBF>2015-7-3</EBF>
+          <EXC>Don't know what kind of values go here</EXC>
+          <ZC>
+          </ZC>
+        </ZB_E>
+        """)
+
+        instance = self.parser.parse()
+        self.assertTrue(instance.new)

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -1,35 +1,53 @@
 import unittest
 
 from lxml.etree import XML
+from lxml.etree import fromstring
 
 from ribxlib import models
 from ribxlib import parsers
+
+
+class TestInspectionPipeParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = parsers.ElementParser(
+            None, models.InspectionPipe, parsers.Mode.INSPECTION)
+
+    def test_work_impossible(self):
+        self.parser.node = fromstring("""
+        <ZB_A xmlns:gml="http://www.opengis.net/gml">
+          <AAA>whee</AAA>
+          <AAD>16D0019</AAD>
+          <AAE>
+            <gml:Point srsDimension="2" srsName="Netherlands-RD">
+              <gml:pos>144054.76 488764.43</gml:pos>
+            </gml:Point>
+          </AAE>
+          <AAF>16D0021</AAF>
+          <AAG>
+            <gml:Point srsDimension="2" srsName="Netherlands-RD">
+              <gml:pos>144003.23 488739.40</gml:pos>
+            </gml:Point>
+          </AAG>
+          <ABF>2015-7-3</ABF>
+          <ADE>Explanation in ADE</ADE>
+          <AXD ADE="Explanation in attribute">Z</AXD>
+        </ZB_A>
+        """)
+        instance = self.parser.parse()
+
+        self.assertTrue(instance)
+        self.assertTrue(instance.work_impossible)
+        self.assertTrue('Andere reden' in instance.work_impossible)
+        self.assertTrue(
+            'Explanation in ADE' in instance.work_impossible)
+        self.assertTrue(
+            'Explanation in attribute' in instance.work_impossible)
 
 
 class TestThingParser(unittest.TestCase):
     def setUp(self):
         self.parser = parsers.ElementParser(
             None, models.Drain, parsers.Mode.INSPECTION)
-
-    def test_work_impossible(self):
-        self.parser.node = XML("""
-        <ZB_E>
-          <EAA>whee</EAA>
-          <EBF>2015-7-3</EBF>
-          <EDE>Explanation in EDE</EDE>
-          <EXD EDE="Explanation in attribute">misc</EXD>
-        </ZB_E>
-        """)
-        instance = self.parser.parse()
-
-        self.assertTrue(instance)
-        self.assertTrue(instance.work_impossible)
-
-        self.assertTrue('misc' in instance.work_impossible)
-        self.assertTrue(
-            'Explanation in EDE' in instance.work_impossible)
-        self.assertTrue(
-            'Explanation in attribute' in instance.work_impossible)
 
     def test_item_is_not_new(self):
         self.parser.node = XML("""

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -1,0 +1,32 @@
+import unittest
+
+from lxml.etree import XML
+
+from ribxlib import models
+from ribxlib import parsers
+
+
+class TestThingParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = parsers.ThingParser(
+            None, models.Drain, parsers.Mode.INSPECTION)
+
+    def test_work_impossible(self):
+        self.parser.node = XML("""
+        <ZB_E>
+          <EAA>whee</EAA>
+          <EBF>2015-7-3</EBF>
+          <EDE>Explanation in EDE</EDE>
+          <EXD EDE="Explanation in attribute">misc</EXD>
+        </ZB_E>
+        """)
+        instance = self.parser.parse()
+
+        self.assertTrue(instance)
+        self.assertTrue(instance.work_impossible)
+
+        self.assertTrue('misc' in instance.work_impossible)
+        self.assertTrue(
+            'Explanation in EDE' in instance.work_impossible)
+        self.assertTrue(
+            'Explanation in attribute' in instance.work_impossible)

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -8,7 +8,7 @@ from ribxlib import parsers
 
 class TestThingParser(unittest.TestCase):
     def setUp(self):
-        self.parser = parsers.ThingParser(
+        self.parser = parsers.ElementParser(
             None, models.Drain, parsers.Mode.INSPECTION)
 
     def test_work_impossible(self):


### PR DESCRIPTION
- Refactored parsers.py a lot; there is now a single parser for
  all types of element.

- Return "InspectionManholes" and "CleaningManholes" separately (and
  the same for pipes). This means lizard-progress can check that the
  right type was used, which will protect against some annoying errors
  users made (uploading a file to the wrong Activity and having it
  accepted, overwriting the right data).

- Check for "XD" tags in element headers, which signify that it was not
  possible to do that part of the assigned work. The commentary is
  gatherered and returned too, for use in lizard-progress.

- Check for "XC" tags in element headers, which signify that the element
  was not part of the assigned work ("found in the field").