### PR TITLE
Storing info on specific kind of observations ("hellinghoek")

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ Changelog of ribxlib
   the first observation we're looking at in more depth. (Which means the
   implementation might change later on).
 
+- Changed local development setup to use docker. Including the now-customary
+  ``Jenkinsfile`` for automatic tests.
+
+  Note: there's a small change regarding the bootstrap/buildout setup that's
+  explained in the README.
+
 
 0.9 (2016-12-07)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,15 @@ Changelog of ribxlib
 0.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added ``bin/bin/ribxdebug`` helper tool to print the info parsed from a
+  .ribx file.
+
+- Added parsing of angle observarions ("hellinghoek") as that's needed for a
+  quality checker.
+
+  Previously, observations were only inspected for their media files. This is
+  the first observation we're looking at in more depth. (Which means the
+  implementation might change later on).
 
 
 0.9 (2016-12-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog of ribxlib
 - Added ``bin/bin/ribxdebug`` helper tool to print the info parsed from a
   .ribx file.
 
-- Added parsing of angle observarions ("hellinghoek") as that's needed for a
+- Added parsing of observation *types* and *distance* as that's needed for a
   quality checker.
 
   Previously, observations were only inspected for their media files. This is

--- a/README.rst
+++ b/README.rst
@@ -68,3 +68,15 @@ And to run the tests::
 Or alternatively::
 
   $ docker-compose run web bin/test
+
+
+Handy debug script
+------------------
+
+There's a handy debug script that prints out information on what's been found
+in an ribx file::
+
+  $ docker-compose run web bin/ribxdebug some-file.ribx
+
+(Note: the file should be accessible for the command running inside the
+docker. ``~/Downloads/some-file.ribx`` won't work :-) )

--- a/README.rst
+++ b/README.rst
@@ -80,3 +80,6 @@ in an ribx file::
 
 (Note: the file should be accessible for the command running inside the
 docker. ``~/Downloads/some-file.ribx`` won't work :-) )
+
+To adjust the output, you should look at the various ``.print_for_debug()``
+methods in ``models.py`` first. The actual main script is in ``script.py``.

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Handy debug script
 ------------------
 
 There's a handy debug script that prints out information on what's been found
-in an ribx file::
+in a ribx file::
 
   $ docker-compose run web bin/ribxdebug some-file.ribx
 

--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,23 @@ The following checks are currently implemented:
   If the reason is 'Z' the '?DE' tag is parsed as the reason.
 - ?XC (a new sewerage element that wasn't on the planning)
 - ?ZC (observations, must be empty in PREINSPECTION mode)
+
+
+Local setup
+-----------
+
+There's a docker, so do a one-time-only::
+
+  $ docker-compose build
+
+There's no `bootstrap.py` anymore, instead just run::
+
+  $ docker-compose run web buildout
+
+And to run the tests::
+
+  $ docker-compose up
+
+Or alternatively::
+
+  $ docker-compose run web bin/test

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -89,8 +89,6 @@ class Pipe(SewerElement):
         super(Pipe, self).__init__(ref)
         self.manhole1 = None
         self.manhole2 = None
-        # We're explicitly interested in angle observations ('hellingmeting')
-        self.angle_observations = []
 
     def __str__(self):
         return self.ref
@@ -108,10 +106,6 @@ class Pipe(SewerElement):
     def print_for_debug(self):
         super(Pipe, self).print_for_debug()
         print("From manhole %s to manhole %s" % (self.manhole1, self.manhole2))
-        if self.angle_observations:
-            print("%s angle observations" % len(self.angle_observations))
-            for angle_observation in self.angle_observations:
-                print("    %.02f" % angle_observation.lengthwise_location)
 
 
 class InspectionPipe(Pipe):
@@ -120,6 +114,17 @@ class InspectionPipe(Pipe):
     def __init__(self, ref):
         super(InspectionPipe, self).__init__(ref)
         self.manhole_start = None  # The starting manhole of the inspection
+        self.expected_inspection_length = None
+        # We're explicitly interested in angle observations ('hellingmeting')
+        self.angle_observations = []
+
+    def print_for_debug(self):
+        super(InspectionPipe, self).print_for_debug()
+        print("Expected inspection length: %s" % self.expected_inspection_length)
+        if self.angle_observations:
+            print("%s angle observations" % len(self.angle_observations))
+            for angle_observation in self.angle_observations:
+                print("    %.02f" % angle_observation.distance)
 
 
 class CleaningPipe(Pipe):
@@ -206,4 +211,4 @@ class AngleObservation(Observation):
 
     def __init__(self, zc_node):
         super(AngleObservation, self).__init__(zc_node)
-        self.lengthwise_location = float(zc_node.xpath('I')[0].text.strip())
+        self.distance = float(zc_node.xpath('I')[0].text.strip())

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -116,17 +116,18 @@ class InspectionPipe(Pipe):
         self.manhole_start = None  # The starting manhole of the inspection
         self.expected_inspection_length = None  # ABQ
         self.segment_length = None  # ACG
-        # We're explicitly interested in angle observations ('hellingmeting')
-        self.angle_observations = []
+        self.observations = []
 
     def print_for_debug(self):
         super(InspectionPipe, self).print_for_debug()
         print("Expected inspection length: %s" % self.expected_inspection_length)
         print("Segment length: %s" % self.segment_length)
-        if self.angle_observations:
-            print("%s angle observations" % len(self.angle_observations))
-            for angle_observation in self.angle_observations:
-                print("    %.02f" % angle_observation.distance)
+        if self.observations:
+            print("%s observations" % len(self.observations))
+            for observation in self.observations:
+                print("    %s %s: %.02f" % (observation.observation_type,
+                                            observation.type_hint(),
+                                            observation.distance))
 
 
 class CleaningPipe(Pipe):
@@ -192,6 +193,16 @@ class Observation(object):
     """Represents the data in a ZC record, and interprets it."""
     def __init__(self, zc_node):
         self.zc_node = zc_node
+        self.distance = self._extract_value('I')
+        if self.distance is not None:
+            self.distance = float(self.distance)
+        self.observation_type = self._extract_value('A')
+
+    def _extract_value(self, tag_name):
+        try:
+            return self.zc_node.xpath(tag_name)[0].text.strip()
+        except:  # Bare except
+            return None
 
     def media(self):
         """Generate the filenames mentioned. Raises ParseException if something
@@ -208,9 +219,9 @@ class Observation(object):
             _check_filename(path)
             yield path
 
-
-class AngleObservation(Observation):
-
-    def __init__(self, zc_node):
-        super(AngleObservation, self).__init__(zc_node)
-        self.distance = float(zc_node.xpath('I')[0].text.strip())
+    def type_hint(self):
+        known = {'BXA': 'hellingmeting',
+                 'BDC': 'afbreking inspectie',
+                 'BCE': 'afbreking',
+                 }
+        return known.get(self.observation_type, '')

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -71,6 +71,13 @@ class SewerElement(object):
         # True if a '*XC' tag was used ("ontbreekt in opdracht")
         self.new = False
 
+    def print_for_debug(self):
+        print(self.ref)
+        print('-' * len(self.ref))
+        print('')
+        print('Inspection date: %s' % self.inspection_date)
+        print('Number of expected media files: %s' % len(self.media))
+
 
 class Pipe(SewerElement):
     """Sewerage pipe (`rioolbuis` in Dutch).
@@ -82,6 +89,8 @@ class Pipe(SewerElement):
         super(Pipe, self).__init__(ref)
         self.manhole1 = None
         self.manhole2 = None
+        # We're explicitly interested in angle observations ('hellingmeting')
+        self.angle_observations = []
 
     def __str__(self):
         return self.ref
@@ -95,6 +104,14 @@ class Pipe(SewerElement):
             return line
         except Exception as e:
             logger.error(e)
+
+    def print_for_debug(self):
+        super(Pipe, self).print_for_debug()
+        print("From manhole %s to manhole %s" % (self.manhole1, self.manhole2))
+        if self.angle_observations:
+            print("%s angle observations" % len(self.angle_observations))
+            for angle_observation in self.angle_observations:
+                print("    %.02f" % angle_observation.lengthwise_location)
 
 
 class InspectionPipe(Pipe):
@@ -183,3 +200,10 @@ class Observation(object):
             path = m_node.text.strip()
             _check_filename(path)
             yield path
+
+
+class AngleObservation(Observation):
+
+    def __init__(self, zc_node):
+        super(AngleObservation, self).__init__(zc_node)
+        self.lengthwise_location = float(zc_node.xpath('I')[0].text.strip())

--- a/ribxlib/models.py
+++ b/ribxlib/models.py
@@ -114,13 +114,15 @@ class InspectionPipe(Pipe):
     def __init__(self, ref):
         super(InspectionPipe, self).__init__(ref)
         self.manhole_start = None  # The starting manhole of the inspection
-        self.expected_inspection_length = None
+        self.expected_inspection_length = None  # ABQ
+        self.segment_length = None  # ACG
         # We're explicitly interested in angle observations ('hellingmeting')
         self.angle_observations = []
 
     def print_for_debug(self):
         super(InspectionPipe, self).print_for_debug()
         print("Expected inspection length: %s" % self.expected_inspection_length)
+        print("Segment length: %s" % self.segment_length)
         if self.angle_observations:
             print("%s angle observations" % len(self.angle_observations))
             for angle_observation in self.angle_observations:

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -207,10 +207,8 @@ class ElementParser(object):
             instance.media.update(observation.media())
 
         if issubclass(self.model, models.InspectionPipe):
-            # We're specifically interested in angle observations
             for observation in self.get_observations():
-                if isinstance(observation, models.AngleObservation):
-                    instance.angle_observations.append(observation)
+                instance.observations.append(observation)
 
         # All well...
         return instance
@@ -384,7 +382,4 @@ class ElementParser(object):
             raise Exception(msg)
 
         for zc_node in node_set:
-            if zc_node.xpath('A')[0].text.strip() == 'BXA':
-                yield models.AngleObservation(zc_node)
-            else:
-                yield models.Observation(zc_node)
+            yield models.Observation(zc_node)

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -200,6 +200,12 @@ class ElementParser(object):
         for observation in self.get_observations():
             instance.media.update(observation.media())
 
+        if issubclass(self.model, models.InspectionPipe):
+            # We're specifically interested in angle observations
+            for observation in self.get_observations():
+                if isinstance(observation, models.AngleObservation):
+                    instance.angle_observations.append(observation)
+
         # All well...
         return instance
 
@@ -372,4 +378,7 @@ class ElementParser(object):
             raise Exception(msg)
 
         for zc_node in node_set:
-            yield models.Observation(zc_node)
+            if zc_node.xpath('A')[0].text.strip() == 'BXA':
+                yield models.AngleObservation(zc_node)
+            else:
+                yield models.Observation(zc_node)

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -177,8 +177,12 @@ class ElementParser(object):
             if issubclass(self.model, models.InspectionPipe):
                 if self.mode == Mode.INSPECTION:
                     instance.manhole_start = self.get_manhole_start(instance)
-                    value, sourceline = self.tag_value('BQ', complain=True)
-                    instance.expected_inspection_length = float(value)
+                    value, sourceline = self.tag_value('BQ')
+                    if value is not None:
+                        instance.expected_inspection_length = float(value)
+                    value2, sourceline = self.tag_value('CG')
+                    if value2 is not None:
+                        instance.segment_length = float(value2)
 
         else:
             # ?AB holds coordinates

--- a/ribxlib/parsers.py
+++ b/ribxlib/parsers.py
@@ -177,6 +177,8 @@ class ElementParser(object):
             if issubclass(self.model, models.InspectionPipe):
                 if self.mode == Mode.INSPECTION:
                     instance.manhole_start = self.get_manhole_start(instance)
+                    value, sourceline = self.tag_value('BQ', complain=True)
+                    instance.expected_inspection_length = float(value)
 
         else:
             # ?AB holds coordinates

--- a/ribxlib/script.py
+++ b/ribxlib/script.py
@@ -1,0 +1,26 @@
+# (c) Nelen & Schuurmans.  GPL licensed, see LICENSE.rst.
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import ntpath
+import os
+import sys
+
+from osgeo import ogr
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) < 2:
+        logger.critical("Pass in a ribx filename")
+        sys.exit(1)
+
+    filename = sys.argv[1]
+    logger.info("Reading %s", filename)

--- a/ribxlib/script.py
+++ b/ribxlib/script.py
@@ -7,13 +7,18 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-import ntpath
-import os
 import sys
 
-from osgeo import ogr
+from ribxlib import parsers
 
 logger = logging.getLogger(__name__)
+
+POSSIBLE_ITEM_LISTS = ['inspection_pipes',
+                       'cleaning_pipes',
+                       'inspection_manholes',
+                       'cleaning_manholes',
+                       'drains',
+                   ]
 
 
 def main():
@@ -23,4 +28,19 @@ def main():
         sys.exit(1)
 
     filename = sys.argv[1]
-    logger.info("Reading %s", filename)
+    logger.info("Reading %s (in 'inspection' mode)", filename)
+
+    ribx, error_log = parsers.parse(open(filename), parsers.Mode.INSPECTION)
+    if error_log:
+        logger.error("Error log found:\n%s", error_log)
+
+    for item_list_name in POSSIBLE_ITEM_LISTS:
+        item_list = getattr(ribx, item_list_name)
+        title = "%s: %s items" % (item_list_name, len(item_list))
+        print(title)
+        print('=' * len(title))
+        print('')
+
+        for item in item_list:
+            item.print_for_debug()
+            print('')

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -163,9 +163,27 @@ class TestThingParser(unittest.TestCase):
           <EBG>14:02:56</EBG>
           <EXC>Don't know what kind of values go here</EXC>
           <ZC>
+            <A>some type</A>
           </ZC>
         </ZB_E>
         """)
 
         with self.assertRaises(Exception):
             self.parser.parse()
+
+    def test_bxa_observation_is_angle_observation(self):
+        self.parser.node = XML("""
+        <ZB_E>
+          <EAA>whee</EAA>
+          <EBF>2015-7-3</EBF>
+          <EBG>14:02:56</EBG>
+          <EXC>Don't know what kind of values go here</EXC>
+          <ZC>
+            <A>BXA</A>
+            <I>5</I>
+          </ZC>
+        </ZB_E>
+        """)
+        self.parser.parse()
+        observations = list(self.parser.get_observations())
+        self.assertTrue(isinstance(observations[0], models.AngleObservation))

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -36,6 +36,7 @@ class TestInspectionPipeParser(unittest.TestCase):
             </gml:Point>
           </AAG>
           <ABF>2015-7-3</ABF>
+          <ABQ>25</ABQ>
           <ADE>Explanation in ADE</ADE>
           <AXD ADE="Explanation in attribute">Z</AXD>
         </ZB_A>

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -171,7 +171,7 @@ class TestThingParser(unittest.TestCase):
         with self.assertRaises(Exception):
             self.parser.parse()
 
-    def test_bxa_observation_is_angle_observation(self):
+    def test_observation_type(self):
         self.parser.node = XML("""
         <ZB_E>
           <EAA>whee</EAA>
@@ -186,4 +186,4 @@ class TestThingParser(unittest.TestCase):
         """)
         self.parser.parse()
         observations = list(self.parser.get_observations())
-        self.assertTrue(isinstance(observations[0], models.AngleObservation))
+        self.assertEqual(observations[0].observation_type, 'BXA')

--- a/ribxlib/tests/test_parsers.py
+++ b/ribxlib/tests/test_parsers.py
@@ -99,6 +99,7 @@ class TestThingParser(unittest.TestCase):
           <EAA>whee</EAA>
           <EBF>2015-7-3</EBF>
           <ZC>
+            <A>some type</A>
           </ZC>
         </ZB_E>
         """)
@@ -113,7 +114,8 @@ class TestThingParser(unittest.TestCase):
           <EBF>2015-7-3</EBF>
           <EXC>Don't know what kind of values go here</EXC>
           <ZC>
-          </ZC>
+            <A>some type</A>
+        </ZC>
         </ZB_E>
         """)
 
@@ -127,6 +129,7 @@ class TestThingParser(unittest.TestCase):
           <EBF>2015-7-3</EBF>
           <EXC>Don't know what kind of values go here</EXC>
           <ZC>
+            <A>some type</A>
           </ZC>
         </ZB_E>
         """)
@@ -142,6 +145,7 @@ class TestThingParser(unittest.TestCase):
           <EBG>14:02:56</EBG>
           <EXC>Don't know what kind of values go here</EXC>
           <ZC>
+            <A>some type</A>
           </ZC>
         </ZB_E>
         """)

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(name='ribxlib',
       extras_require={'test': tests_require},
       entry_points={
           'console_scripts': [
+              'ribxdebug = ribxlib.script:main',
           ]},
       )


### PR DESCRIPTION
From the changelog:

- Added ``bin/bin/ribxdebug`` helper tool to print the info parsed from a
  .ribx file.

- Added parsing of angle observarions ("hellinghoek") as that's needed for a
  quality checker.

  Previously, observations were only inspected for their media files. This is
  the first observation we're looking at in more depth. (Which means the
  implementation might change later on).
